### PR TITLE
Add support for aarch64c ASM dispatch.

### DIFF
--- a/src/GLX/glvnd_genentry.c
+++ b/src/GLX/glvnd_genentry.c
@@ -95,19 +95,14 @@ extern char glx_entrypoint_end[];
 
 #elif defined(USE_AARCH64_ASM)
 
+#define STUB_SIZE 16
 #if defined(__CHERI_PURE_CAPABILITY__)
-#define STUB_SIZE 32
 #define STUB_ASM_ARCH(slot) \
     "adrp c16, entrypointFunctions + " slot "*16\n" \
-    "str c17, [csp, #-16]\n" \
-    "adrp c17, 0\n" \
-    "scvalue c17, c17, x16\n" \
-    "ldr c16, [c17, #:lo12:(entrypointFunctions + " slot "*16)]\n" \
-    "ldr c17, [csp], #16\n" \
+    "ldr c16, [c16, #:lo12:(entrypointFunctions + " slot "*16)]\n" \
     "br c16\n" \
     "nop\n"
 #else   // !__CHERI_PURE_CAPABILITY__
-#define STUB_SIZE 16
 #define STUB_ASM_ARCH(slot) \
     "hint #34\n" \
     "adrp x16, entrypointFunctions + " slot "*8\n" \

--- a/src/GLX/glvnd_genentry.c
+++ b/src/GLX/glvnd_genentry.c
@@ -95,12 +95,25 @@ extern char glx_entrypoint_end[];
 
 #elif defined(USE_AARCH64_ASM)
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+#define STUB_SIZE 32
+#define STUB_ASM_ARCH(slot) \
+    "adrp c16, entrypointFunctions + " slot "*16\n" \
+    "str c17, [csp, #-16]\n" \
+    "adrp c17, 0\n" \
+    "scvalue c17, c17, x16\n" \
+    "ldr c16, [c17, #:lo12:(entrypointFunctions + " slot "*16)]\n" \
+    "ldr c17, [csp], #16\n" \
+    "br c16\n" \
+    "nop\n"
+#else   // !__CHERI_PURE_CAPABILITY__
 #define STUB_SIZE 16
 #define STUB_ASM_ARCH(slot) \
     "hint #34\n" \
     "adrp x16, entrypointFunctions + " slot "*8\n" \
     "ldr x16, [x16, #:lo12:(entrypointFunctions + " slot "*8)]\n" \
     "br x16\n"
+#endif  // !__CHERI_PURE_CAPABILITY__
 
 #elif defined(USE_PPC64_ASM) && defined(_CALL_ELF) && (_CALL_ELF == 2)
 
@@ -166,7 +179,15 @@ static void *DefaultDispatchFunc(void)
 
 static GLVNDentrypointStub GetEntrypointStub(int index)
 {
+#if defined(__CHERI_PURE_CAPABILITY__)
+    const ptraddr_t sentry_addr = __builtin_cheri_address_get(glx_entrypoint_start);
+    const ptraddr_t stub_addr = sentry_addr + (index * STUB_SIZE);
+    const void* pcc = __builtin_cheri_program_counter_get();
+    uintptr_t result_cap = (uintptr_t) __builtin_cheri_address_set(pcc, stub_addr);
+    return (GLVNDentrypointStub) __builtin_cheri_seal_entry(result_cap | 1);
+#else   // !__CHERI_PURE_CAPABILITY__
     return (GLVNDentrypointStub) (glx_entrypoint_start + (index * STUB_SIZE));
+#endif  // !__CHERI_PURE_CAPABILITY__
 }
 
 GLVNDentrypointStub glvndGenerateEntrypoint(const char *procName)

--- a/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
+++ b/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
@@ -74,8 +74,8 @@
     "adrp c0, :got:_glapi_Current\n\t"                \
     "ldr c0, [c0, #:got_lo12:_glapi_Current]\n\t"     \
     "ldr c0, [c0]\n\t"                                \
-    "gcvalue x1, c0\n\t"                              \
-    "cbz x1, 10f\n\t"                                 \
+    "gcvalue x0, c0\n\t"                              \
+    "cbz x0, 10f\n\t"                                 \
     "11:\n\t"        /* found dispatch */             \
     "ldr x1, 3f\n\t"                                  \
     "ldr c16, [c0, x1]\n\t"                           \

--- a/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
+++ b/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
@@ -68,6 +68,35 @@
  * The 'found_dispatch' section computes the correct offset in the dispatch
  * table then does a branch without link to the function address.
  */
+#if defined(__CHERI_PURE_CAPABILITY__)
+#define STUB_ASM_CODE(slot)                           \
+    "stp c1, c0, [csp, #-32]!\n\t"                    \
+    "adrp c0, :got:_glapi_Current\n\t"                \
+    "ldr c0, [c0, #:got_lo12:_glapi_Current]\n\t"     \
+    "ldr c0, [c0]\n\t"                                \
+    "gcvalue x1, c0\n\t"                              \
+    "cbz x1, 10f\n\t"                                 \
+    "11:\n\t"        /* found dispatch */             \
+    "ldr x1, 3f\n\t"                                  \
+    "ldr c16, [c0, x1]\n\t"                           \
+    "ldp c1, c0, [csp], #32\n\t"                      \
+    "br c16\n\t"                                      \
+    "10:\n\t"        /* lookup dispatch */            \
+    "stp c30, c9, [csp, #-32]!\n\t"                   \
+    "stp c7, c6, [csp, #-32]!\n\t"                    \
+    "stp c5, c4, [csp, #-32]!\n\t"                    \
+    "stp c3, c2, [csp, #-32]!\n\t"                    \
+    "adrp c0, :got:_glapi_get_current\n\t"            \
+    "ldr c0, [c0, #:got_lo12:_glapi_get_current]\n\t" \
+    "blr c0\n\t"                                      \
+    "ldp c3, c2, [csp], #32\n\t"                      \
+    "ldp c5, c4, [csp], #32\n\t"                      \
+    "ldp c7, c6, [csp], #32\n\t"                      \
+    "ldp c30, c9, [csp], #32\n\t"                     \
+    "b 11b\n\t"                                       \
+    "3:\n\t"                                          \
+    ".xword " slot " * 16\n\t" /* size of (void *) */
+#else   // !__CHERI_PURE_CAPABILITY__
 #define STUB_ASM_CODE(slot)                           \
     "hint #34\n\t"                                    \
     "stp x1, x0, [sp, #-16]!\n\t"                     \
@@ -95,6 +124,7 @@
     "b 11b\n\t"                                       \
     "3:\n\t"                                          \
     ".xword " slot " * 8\n\t" /* size of (void *) */
+#endif  // !__CHERI_PURE_CAPABILITY__
 
 __asm__(".section wtext,\"ax\"\n"
         ".balign " U_STRINGIFY(GLDISPATCH_PAGE_SIZE) "\n"

--- a/src/GLdispatch/vnd-glapi/entry_simple_asm.c
+++ b/src/GLdispatch/vnd-glapi/entry_simple_asm.c
@@ -53,5 +53,13 @@
 
 mapi_func entry_get_public(int index)
 {
+#if defined(__CHERI_PURE_CAPABILITY__)
+    const ptraddr_t sentry_addr = __builtin_cheri_address_get(public_entry_start);
+    const ptraddr_t stub_addr = sentry_addr + (index * entry_stub_size);
+    const void* pcc = __builtin_cheri_program_counter_get();
+    uintptr_t result_cap = (uintptr_t) __builtin_cheri_address_set(pcc, stub_addr);
+    return (mapi_func) __builtin_cheri_seal_entry(result_cap | 1);
+#else   // !__CHERI_ PURE_CAPABILITY__
     return (mapi_func)(public_entry_start + (index * entry_stub_size));
+#endif  // !__CHERI_PURE_CAPABILITY__
 }


### PR DESCRIPTION
The existing aarch64 ASM dispatch mechanism has been adapted for the Morello ISA, replacing loads and stores with instructions to load and store capability values.

In a number of cases values are computed as offsets from a sentry value, which results in an invalid capability. This code has been changed to recomputed capabilities using the program counter, before (where necessary) resealing the capability to an sentry.